### PR TITLE
Vercel 환경에서 Astro의 trailingSlash 설정이 작동하지 않아 vercel.json을 추가

### DIFF
--- a/src/components/Base/BaseHead.astro
+++ b/src/components/Base/BaseHead.astro
@@ -8,7 +8,7 @@ export interface Props {
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site)
   .toString()
-  .replace(/\+$/, "");
+  .replace(/\/+$/, "");
 
 const { title, description, keywords } = Astro.props;
 const imageURL = new URL("/images/logo.png", Astro.url);

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "trailingSlash": false
+}


### PR DESCRIPTION
* Vercel 환경에서 Astro의 trailingSlash 설정이 작동하지 않아 vercel.json을 추가했어요.
* 잘못된 canonicalURL을 반환하는 정규식을 수정했어요.