### PR TITLE
`애플 실리콘(M1, M2)에서 docker 로 rockylinux 실행하기` 메모 작성

### DIFF
--- a/src/content/note/20231017-docker-platform/index.md
+++ b/src/content/note/20231017-docker-platform/index.md
@@ -1,0 +1,32 @@
+---
+title: "애플 실리콘(M1, M2)에서 docker 로 rockylinux 실행하기"
+description: "docker: no matching manifest for linux/arm64/v8 in the manifest list entries."
+date: 2023-10-17
+tags: ["docker"]
+---
+
+# rockylinux 컨테이너 생성 및 실행
+
+```bash
+docker run \
+--platform linux/amd64 \
+--privileged -d \
+rockylinux/rockylinux /sbin/init
+```
+
+- `-platform`: 컨테이너를 실행할 때 사용할 플랫폼
+  - 작성일 기준으로 arm64와 완벽하게 호환되지 않아 `linux/amd64` 아키텍처로 실행
+- `--privileged`: 컨테이너가 모든 호스트 장치에 접근하도록 권한을 부여
+- `-d`: 백그라운드 실행
+- `/sbin/init`: 시스템 초기화 작업 프로세스 실행
+  - 서비스나 데몬 등 일반 리눅스 시스템과 유사한 프로세스 경험을 위함
+
+-`p`: 포트 포워딩 [HOST]:[CONTAINER]
+
+# rockylinux 세션 접속
+
+```bash
+docker exec -it [container_id_or_name] /bin/bash
+```
+
+- '-it': 컨테이너와 상호작용 가능한 터미널 환경을 생성

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -37,12 +37,12 @@
 
   li {
     ul {
-      @apply mt-4;
+      @apply mt-2;
     }
   }
 
   li:not(:last-child) {
-    @apply mb-4;
+    @apply mb-2;
   }
 
   img {


### PR DESCRIPTION
* `애플 실리콘(M1, M2)에서 docker 로 rockylinux 실행하기` 메모를 작성했어요.
* 콘텐츠 li 요소의 간격을 수정했어요